### PR TITLE
chore: add `@tru_id/tru-sdk-react-native` to `example` `package.json`

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,8 @@
     "axios": "^0.21.1",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-dotenv": "^2.5.3"
+    "react-native-dotenv": "^2.5.3",
+    "@tru_id/tru-sdk-react-native": "^0.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
added our SDK to the example's package.json as the example project depends on it but it's missing. also using the latest version